### PR TITLE
add wheel to build environment

### DIFF
--- a/template/pixi.toml.jinja
+++ b/template/pixi.toml.jinja
@@ -25,6 +25,7 @@ test-coverage = "pytest --cov={{ project_slug_snake_case }} --cov-report=xml --c
 [feature.build.dependencies]
 python-build = "*"
 twine = "*"
+wheel = "*"
 [feature.build.tasks]
 build-wheel = "python -m build --no-isolation ."
 check-wheel = "twine check dist/*"


### PR DESCRIPTION
python 3.13 doesn't come with `wheel`