### PR TITLE
remove upload to testpypi

### DIFF
--- a/template/.github/workflows/build.yml
+++ b/template/.github/workflows/build.yml
@@ -41,9 +41,5 @@ jobs:
         with:
           name: artifact
           path: dist
-      - name: Publish package on TestPyPi
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
-        with:
-          repository-url: https://test.pypi.org/legacy/
       - name: Publish package on PyPi
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4


### PR DESCRIPTION
the pypi upload action now generates attestation files and fails when executed multiple times