### PR TITLE
Add OpenSSF scorecard to repo and template

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,79 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: "34 5 * * 0"
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
+    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+          # (Optional) Uncomment file_mode if you have a .gitattributes with files marked export-ignore
+          # file_mode: git
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@97a2bfd2a3d26d458da69e548f7f859d6fca634d # v3.28.15
+        with:
+          sarif_file: results.sarif

--- a/template/.github/workflows/scorecard.yml
+++ b/template/.github/workflows/scorecard.yml
@@ -1,0 +1,79 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: "34 5 * * 0"
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
+    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+          # (Optional) Uncomment file_mode if you have a .gitattributes with files marked export-ignore
+          # file_mode: git
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@97a2bfd2a3d26d458da69e548f7f859d6fca634d # v3.28.15
+        with:
+          sarif_file: results.sarif

--- a/template/.github/workflows/scorecard.yml.jinja
+++ b/template/.github/workflows/scorecard.yml.jinja
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
 {%- endraw -%}
-{% set github_repo_url = github_url.split("/")[-2:].join("/") %}
-    if: (github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request') && github.repository == '{{ github_repo_url }}'
-{%- raw -%}
+{% set github_repo_url = github_url.split("/")[-2:] %}
+    if: (github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request') && github.repository == '{{ github_repo_url|join("/") }}'
+{% raw %}
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/template/.github/workflows/scorecard.yml.jinja
+++ b/template/.github/workflows/scorecard.yml.jinja
@@ -27,7 +27,7 @@ jobs:
 {%- endraw -%}
 {%- set github_repo_url = github_url.split("/")[-2:] -%}
     if: (github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request') && github.repository == '{{ github_repo_url|join("/") }}'
-{% raw %}
+{%- raw %}
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/template/.github/workflows/scorecard.yml.jinja
+++ b/template/.github/workflows/scorecard.yml.jinja
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
 {%- endraw -%}
-{% set github_repo_url = github_url.split("/")[-2:] %}
+{%- set github_repo_url = github_url.split("/")[-2:] -%}
     if: (github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request') && github.repository == '{{ github_repo_url|join("/") }}'
 {% raw %}
     permissions:
@@ -81,4 +81,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@97a2bfd2a3d26d458da69e548f7f859d6fca634d # v3.28.15
         with:
           sarif_file: results.sarif
-{%- endraw -%}
+{%- endraw %}

--- a/template/.github/workflows/scorecard.yml.jinja
+++ b/template/.github/workflows/scorecard.yml.jinja
@@ -1,3 +1,4 @@
+{%- raw -%}
 # This workflow uses actions that are not certified by GitHub. They are provided
 # by a third-party and are governed by separate terms of service, privacy
 # policy, and support documentation.
@@ -23,7 +24,10 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
-    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
+{%- endraw -%}
+{% set github_repo_url = github_url.split("/")[-2:].join("/") %}
+    if: (github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request') && github.repository == '{{ github_repo_url }}'
+{%- raw -%}
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
@@ -77,3 +81,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@97a2bfd2a3d26d458da69e548f7f859d6fca634d # v3.28.15
         with:
           sarif_file: results.sarif
+{%- endraw -%}


### PR DESCRIPTION
Some of our repositories are anyways indexed by the OpenSSF and this will ensure that all missing values are filled in (i.e. better scores) and also get us better visibility into our own scores via GitHub's security tab.