### PR TITLE
Do not expose stdlib imports in package namespace

### DIFF
--- a/template/{{ project_slug_snake_case }}/__init__.py.jinja
+++ b/template/{{ project_slug_snake_case }}/__init__.py.jinja
@@ -1,8 +1,8 @@
-import importlib.metadata
-import warnings
+import warnings as _warnings
+from importlib import metadata as _metadata
 
 try:
-    __version__ = importlib.metadata.version(__name__)
-except importlib.metadata.PackageNotFoundError as e:  # pragma: no cover
-    warnings.warn(f"Could not determine version of {__name__}\n{e!s}", stacklevel=2)
+    __version__ = _metadata.version(__name__)
+except _metadata.PackageNotFoundError as e:  # pragma: no cover
+    _warnings.warn(f"Could not determine version of {__name__}\n{e!s}", stacklevel=2)
     __version__ = "unknown"


### PR DESCRIPTION
`__init__.py` currently exposes those two imports. It would be cleaner to prefix them as private.