### PR TITLE
Update .gitattributes for pixi.lock file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-pixi.lock merge=binary linguist-language=YAML linguist-generated=true
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff

--- a/template/.gitattributes
+++ b/template/.gitattributes
@@ -1,1 +1,1 @@
-pixi.lock merge=binary linguist-language=YAML linguist-generated=true
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff


### PR DESCRIPTION
Add `-diff` to the `pixi.lock` gitattributes entry to match the default generated by `pixi init`.